### PR TITLE
Add GameRelationSyncManager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,12 @@ apply plugin: 'realm-android'
 apply plugin: "net.ltgt.apt"
 apply from: rootProject.file("gradle/codeQuality.gradle")
 
+ext.versionMajor = 0
+ext.versionMinor = 1
+ext.versionPatch = 0
+ext.versionClassifier = ""
+
+ext.minimumSdkVersion = 16
 
 android {
     compileSdkVersion 25
@@ -28,8 +34,8 @@ android {
         applicationId "com.piticlistudio.playednext"
         minSdkVersion 19
         targetSdkVersion 25
-        versionCode 1
-        versionName "0.01"
+        versionCode generateVersionCode()
+        versionName generateVersionName()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
@@ -44,6 +50,7 @@ android {
         debug {
             testCoverageEnabled = true
         }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -134,4 +141,17 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
         transitive = true;
     }
+}
+
+
+private Integer generateVersionCode() {
+    return ext.minimumSdkVersion * 10000000 + ext.versionMajor * 10000 + ext.versionMinor * 100 + ext.versionPatch
+}
+
+private String generateVersionName() {
+    String versionName = "${ext.versionMajor}.${ext.versionMinor}.${ext.versionPatch}"
+    if (ext.versionClassifier != null && !ext.versionClassifier.isEmpty()) {
+        versionName = versionName + "-" + ext.versionClassifier
+    }
+    return versionName;
 }

--- a/app/src/common/java/com/piticlistudio/playednext/GameFactory.java
+++ b/app/src/common/java/com/piticlistudio/playednext/GameFactory.java
@@ -117,6 +117,7 @@ public class GameFactory {
      */
     public static RealmGame provideRealmGame(int id, String title) {
         RealmGame data = new RealmGame();
+        data.setSyncedAt(System.currentTimeMillis());
         data.setId(id);
         data.setName(title);
         data.setStoryline("storyline");

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
 
         </activity>
 
+        <service android:name=".gamerelation.service.GameRelationSyncService"/>
+
         <activity android:name=".gamerelation.ui.list.view.GameRelationListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/java/com/piticlistudio/playednext/AndroidApplication.java
+++ b/app/src/main/java/com/piticlistudio/playednext/AndroidApplication.java
@@ -1,6 +1,8 @@
 package com.piticlistudio.playednext;
 
 import android.app.Application;
+import android.app.IntentService;
+import android.content.Intent;
 import android.support.annotation.VisibleForTesting;
 
 import com.crashlytics.android.Crashlytics;
@@ -13,6 +15,7 @@ import com.piticlistudio.playednext.game.DaggerGameComponent;
 import com.piticlistudio.playednext.game.GameComponent;
 import com.piticlistudio.playednext.game.GameModule;
 import com.piticlistudio.playednext.game.ui.search.GameSearchComponent;
+import com.piticlistudio.playednext.gamerelation.service.GameRelationSyncService;
 import com.piticlistudio.playednext.gamerelation.ui.detail.GameRelationDetailComponent;
 import com.piticlistudio.playednext.gamerelation.ui.list.GameRelationListComponent;
 import com.piticlistudio.playednext.genre.GenreModule;
@@ -96,6 +99,10 @@ public class AndroidApplication extends Application {
                 schema.get("RealmGameRelation")
                         .renameField("status", "statuses");
             }
+            if (oldVersion == 7) {
+                schema.get("RealmGame")
+                        .addField("syncedAt", long.class);
+            }
         }
     };
 
@@ -105,12 +112,14 @@ public class AndroidApplication extends Application {
         Fabric.with(this, new Crashlytics());
 
         RealmConfiguration config = new RealmConfiguration.Builder(this)
-                .schemaVersion(7)
+                .schemaVersion(8)
                 .migration(migration)
                 .build();
         Realm.setDefaultConfiguration(config);
 
         initializeComponents();
+
+        startService(new Intent(this, GameRelationSyncService.class));
     }
 
     private void initializeComponents() {

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/Game.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/Game.java
@@ -31,6 +31,7 @@ public abstract class Game {
     public List<Genre> genres = new ArrayList<>();
     public List<GameRelease> releases = new ArrayList<>();
     public List<Platform> platforms = new ArrayList<>();
+    public long syncedAt;
 
     public static Game create(int id, String title) {
         return new AutoValue_Game(id, title);

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/GameMapper.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/GameMapper.java
@@ -59,7 +59,7 @@ public class GameMapper implements Mapper<Game, IGameDatasource> {
         Game result = Game.create(data.getId(), data.getName());
         result.storyline = data.getStoryline();
         result.summary = data.getSummary();
-
+        result.syncedAt = data.syncedAt();
         if (data.getCollection().isPresent() && data.getCollection().get().data.isPresent()) {
             result.collection = collectionMapper.transform(data.getCollection().get().getData());
         }

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/RealmGameMapper.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/RealmGameMapper.java
@@ -65,6 +65,7 @@ public class RealmGameMapper implements Mapper<RealmGame, Game> {
         result.setName(data.title());
         result.setStoryline(data.storyline);
         result.setSummary(data.summary);
+        result.setSyncedAt(data.syncedAt);
 
         if (data.cover != null && data.cover.isPresent()) {
             Optional<RealmImageData> image = imageMapper.transform(data.cover.get());

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/IGDBGame.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/IGDBGame.java
@@ -220,4 +220,14 @@ public abstract class IGDBGame implements IGameDatasource {
         }
         return data;
     }
+
+    /**
+     * Returns when this source has been synced with latest data
+     *
+     * @return the time in Unix timestamp
+     */
+    @Override
+    public long syncedAt() {
+        return System.currentTimeMillis();
+    }
 }

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/IGameDatasource.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/IGameDatasource.java
@@ -48,6 +48,12 @@ public interface IGameDatasource {
     String getStoryline();
 
     /**
+     * Returns when this source has been synced with latest data
+     * @return the time in Unix timestamp
+     */
+    long syncedAt();
+
+    /**
      * Returns the collection
      *
      * @return the collection

--- a/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/RealmGame.java
+++ b/app/src/main/java/com/piticlistudio/playednext/game/model/entity/datasource/RealmGame.java
@@ -1,5 +1,7 @@
 package com.piticlistudio.playednext.game.model.entity.datasource;
 
+import android.app.AlarmManager;
+
 import com.fernandocejas.arrow.optional.Optional;
 import com.piticlistudio.playednext.collection.model.entity.datasource.ICollectionData;
 import com.piticlistudio.playednext.collection.model.entity.datasource.RealmCollection;
@@ -46,6 +48,7 @@ public class RealmGame extends RealmObject implements IGameDatasource {
     private RealmList<RealmGenre> genres = new RealmList<>();
     private RealmList<RealmGameRelease> releases = new RealmList<>();
     private RealmList<RealmPlatform> platforms = new RealmList<>();
+    private long syncedAt;
 
     public RealmGame() {
     }
@@ -248,5 +251,19 @@ public class RealmGame extends RealmObject implements IGameDatasource {
 
     public void setPlatforms(RealmList<RealmPlatform> platforms) {
         this.platforms = platforms;
+    }
+
+    public void setSyncedAt(long syncedAt) {
+        this.syncedAt = syncedAt;
+    }
+
+    /**
+     * Returns when this source has been synced with latest data
+     *
+     * @return the time in Unix timestamp
+     */
+    @Override
+    public long syncedAt() {
+        return syncedAt;
     }
 }

--- a/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationServiceComponent.java
+++ b/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationServiceComponent.java
@@ -1,0 +1,21 @@
+package com.piticlistudio.playednext.gamerelation.service;
+
+
+import com.piticlistudio.playednext.di.PerActivity;
+import com.piticlistudio.playednext.di.component.AppComponent;
+import com.piticlistudio.playednext.game.GameModule;
+import com.piticlistudio.playednext.gamerelation.GameRelationModule;
+import com.piticlistudio.playednext.gamerelation.model.entity.GameRelation;
+import com.piticlistudio.playednext.gamerelation.ui.list.GameRelationListModule;
+import com.piticlistudio.playednext.gamerelation.ui.list.view.GameRelationListActivity;
+
+import dagger.Component;
+
+@PerActivity
+@Component(dependencies = {AppComponent.class})
+public interface GameRelationServiceComponent {
+
+    void inject(GameRelationSyncService service);
+
+    GameRelationSyncManager manager();
+}

--- a/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncManager.java
+++ b/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncManager.java
@@ -1,0 +1,53 @@
+package com.piticlistudio.playednext.gamerelation.service;
+
+import android.app.AlarmManager;
+import android.util.Log;
+
+import com.piticlistudio.playednext.game.model.entity.Game;
+import com.piticlistudio.playednext.game.model.repository.IGameRepository;
+import com.piticlistudio.playednext.gamerelation.model.entity.GameRelation;
+import com.piticlistudio.playednext.gamerelation.model.repository.IGameRelationRepository;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.reactivex.functions.Predicate;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * A manager for syncing game relations
+ * Created by jorge on 29/6/17.
+ */
+
+public class GameRelationSyncManager {
+
+    private final IGameRelationRepository localRelationRepository;
+    private final IGameRepository gameRepository;
+
+    @Inject
+    public GameRelationSyncManager(IGameRelationRepository localRelationRepository, IGameRepository gameRepository) {
+        this.localRelationRepository = localRelationRepository;
+        this.gameRepository = gameRepository;
+    }
+
+    public Observable<Game> sync() {
+        return localRelationRepository.loadAll()
+                .take(1)
+                .observeOn(Schedulers.io())
+                .flatMap(iGameRelationDatasources ->
+                        Observable.fromIterable(iGameRelationDatasources)
+                                .filter(gameRelation -> System.currentTimeMillis() - gameRelation.game().syncedAt > AlarmManager.INTERVAL_DAY*3)
+                                .flatMap(gameRelation -> gameRepository.load(gameRelation.game().id())
+                                        .onErrorReturnItem(gameRelation.game())
+                                        .flatMap(game -> gameRepository.save(game).toObservable())
+                                )
+                );
+    }
+}

--- a/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncService.java
+++ b/app/src/main/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncService.java
@@ -1,0 +1,47 @@
+package com.piticlistudio.playednext.gamerelation.service;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.piticlistudio.playednext.AndroidApplication;
+import com.piticlistudio.playednext.di.component.AppComponent;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+
+/**
+ * Service for syncing gamerelation data
+ * Created by jorge on 20/6/17.
+ */
+
+public class GameRelationSyncService extends IntentService {
+
+    private static final String TAG = "GameRelationSyncService";
+
+    GameRelationSyncManager manager;
+
+    public GameRelationSyncService() {
+        super(TAG);
+    }
+
+    protected AppComponent getAppComponent() {
+        return ((AndroidApplication) getApplication()).appComponent;
+    }
+
+    @Override
+    protected void onHandleIntent(@Nullable Intent intent) {
+        GameRelationServiceComponent component = DaggerGameRelationServiceComponent.builder()
+                .appComponent(getAppComponent())
+                .build();
+        component.inject(this);
+
+        manager = component.manager();
+
+        manager.sync()
+                .subscribeOn(AndroidSchedulers.mainThread())
+                .subscribe(game -> Log.d(TAG, "Succesfully synced game = [" + game + "]"),
+                        throwable -> Log.e(TAG, "Failed syncing data: " + throwable.getLocalizedMessage()),
+                        () -> Log.d(TAG, "Completed"));
+    }
+}

--- a/app/src/test/java/com/piticlistudio/playednext/game/model/entity/GameMapperTest.java
+++ b/app/src/test/java/com/piticlistudio/playednext/game/model/entity/GameMapperTest.java
@@ -632,6 +632,25 @@ public class GameMapperTest extends BaseGameTest {
     }
 
     @Test
+    public void given_data_When_Transforms_Then_SetsSyncedAtValues() throws Exception {
+
+        RealmGame data = new RealmGame();
+        data.setName("name");
+        data.setId(10);
+        data.setSyncedAt(5000L);
+
+        when(companyMapper.transform(any())).thenReturn(Optional.absent());
+
+        // Act
+        Optional<Game> result = mapper.transform(data);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isPresent());
+        assertEquals(5000L, result.get().syncedAt);
+    }
+
+    @Test
     public void given_validData_When_Transform_Then_ReturnsGameEntity() throws Exception {
 
         List<NetworkEntityIdRelation<IPlatformData>> platforms = new ArrayList<>();

--- a/app/src/test/java/com/piticlistudio/playednext/game/model/entity/RealmGameMapperTest.java
+++ b/app/src/test/java/com/piticlistudio/playednext/game/model/entity/RealmGameMapperTest.java
@@ -102,6 +102,19 @@ public class RealmGameMapperTest extends BaseGameTest {
     }
 
     @Test
+    public void given_validData_When_Transform_Then_SetsSyncedAtValues() throws Exception {
+
+        Game game = Game.create(10, "title");
+        game.syncedAt = 5000L;
+
+        Optional<RealmGame> result = mapper.transform(game);
+
+        assertNotNull(result);
+        assertTrue(result.isPresent());
+        assertEquals(5000L, result.get().syncedAt());
+    }
+
+    @Test
     public void given_nonPresentCover_When_Transform_Then_ReturnsGameWithoutCover() throws Exception {
         Game game = Game.create(10, "title");
         game.cover = Optional.absent();

--- a/app/src/test/java/com/piticlistudio/playednext/game/model/entity/datasource/IGDBGameTest.java
+++ b/app/src/test/java/com/piticlistudio/playednext/game/model/entity/datasource/IGDBGameTest.java
@@ -214,6 +214,14 @@ public class IGDBGameTest {
     }
 
     @Test
+    public void syncedAt() throws Exception {
+
+        long currentTime = System.currentTimeMillis();
+
+        assertTrue(data.syncedAt() >= currentTime);
+    }
+
+    @Test
     public void given_nullReleaseDates_When_getReleases_Then_ReturnsEmptyList() throws Exception {
 
         data.release_dates = null;

--- a/app/src/test/java/com/piticlistudio/playednext/game/model/entity/datasource/RealmGameTest.java
+++ b/app/src/test/java/com/piticlistudio/playednext/game/model/entity/datasource/RealmGameTest.java
@@ -1,5 +1,7 @@
 package com.piticlistudio.playednext.game.model.entity.datasource;
 
+import android.app.AlarmManager;
+
 import com.fernandocejas.arrow.optional.Optional;
 import com.piticlistudio.playednext.GameFactory;
 import com.piticlistudio.playednext.company.model.entity.datasource.ICompanyData;
@@ -297,6 +299,12 @@ public class RealmGameTest {
             assertTrue(result.get(i).data.isPresent());
             assertEquals(platforms.get(i), result.get(i).getData());
         }
+    }
 
+    @Test
+    public void getSyncedAt() throws Exception {
+        data.setSyncedAt(5000L);
+
+        assertEquals(5000L, data.syncedAt());
     }
 }

--- a/app/src/test/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncManagerTest.java
+++ b/app/src/test/java/com/piticlistudio/playednext/gamerelation/service/GameRelationSyncManagerTest.java
@@ -1,0 +1,162 @@
+package com.piticlistudio.playednext.gamerelation.service;
+
+import com.piticlistudio.playednext.BaseTest;
+import com.piticlistudio.playednext.TestSubjectSchedulerRule;
+import com.piticlistudio.playednext.game.model.entity.Game;
+import com.piticlistudio.playednext.game.model.repository.IGameRepository;
+import com.piticlistudio.playednext.gamerelation.model.entity.GameRelation;
+import com.piticlistudio.playednext.gamerelation.model.repository.IGameRelationRepository;
+import com.piticlistudio.playednext.gamerelation.ui.detail.GameRelationDetailContract;
+import com.piticlistudio.playednext.gamerelation.ui.detail.presenter.GameRelationDetailPresenter;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Test cases for GameRelationSyncManager
+ * Created by jorge on 29/6/17.
+ */
+public class GameRelationSyncManagerTest extends BaseTest {
+
+    @Rule
+    public TestSubjectSchedulerRule testSchedulerRule = new TestSubjectSchedulerRule();
+    @Mock
+    IGameRelationRepository relationRepository;
+    @Mock
+    IGameRepository gameRepository;
+
+    @InjectMocks
+    GameRelationSyncManager manager;
+
+    @Test
+    public void given_emptylist_then_should_not_request_data() throws Exception {
+        doReturn(Observable.just(new ArrayList<>())).when(relationRepository).loadAll();
+
+        // Act
+        TestObserver<Game> result = manager.sync().test();
+        result.awaitTerminalEvent();
+
+        // Assert
+        verify(relationRepository).loadAll();
+        verifyZeroInteractions(gameRepository);
+    }
+
+    @Test
+    public void given_relationsWithSyncedgame_Then_should_not_request_data() throws Exception {
+
+        List<GameRelation> relations = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Game game = Game.create(i, "title");
+            game.syncedAt = System.currentTimeMillis();
+            relations.add(GameRelation.create(game, System.currentTimeMillis()));
+        }
+        doReturn(Observable.just(relations)).when(relationRepository).loadAll();
+
+        // Act
+        TestObserver<Game> result = manager.sync().test();
+        result.awaitTerminalEvent();
+
+        // Assert
+        verify(relationRepository).loadAll();
+        verifyZeroInteractions(gameRepository);
+    }
+
+    @Test
+    public void given_relationsWithNonSyncedData_Then_should_requestDataForUnsyncedOnes() throws Exception {
+        Game syncedGame1 = Game.create(0, "title");
+        syncedGame1.syncedAt = System.currentTimeMillis();
+        Game syncedGame2 = Game.create(1, "title");
+        syncedGame2.syncedAt = System.currentTimeMillis();
+        Game unsyncedGame1 = Game.create(2, "title");
+        Game syncedGame3 = Game.create(3, "title");
+        syncedGame3.syncedAt = System.currentTimeMillis();
+        Game unsyncedGame2 = Game.create(4, "title");
+
+        List<GameRelation> relations = new ArrayList<>();
+        relations.add(GameRelation.create(syncedGame1, System.currentTimeMillis()));
+        relations.add(GameRelation.create(syncedGame2, System.currentTimeMillis()));
+        relations.add(GameRelation.create(unsyncedGame1, System.currentTimeMillis()));
+        relations.add(GameRelation.create(unsyncedGame2, System.currentTimeMillis()));
+        relations.add(GameRelation.create(syncedGame3, System.currentTimeMillis()));
+        doReturn(Observable.just(relations)).when(relationRepository).loadAll();
+
+        final Game updatedGame = Game.create(100, "updated_title");
+        doReturn(Observable.just(updatedGame)).when(gameRepository).load(anyInt());
+        doAnswer(invocation -> Completable.complete()).when(gameRepository).save(updatedGame);
+
+        // Act
+        TestObserver<Game> result = manager.sync().test();
+        result.awaitTerminalEvent();
+
+        // Assert
+        verify(relationRepository).loadAll();
+        verify(gameRepository).load(unsyncedGame1.id());
+        verify(gameRepository).load(unsyncedGame2.id());
+        verify(gameRepository, never()).load(syncedGame1.id());
+        verify(gameRepository, never()).load(syncedGame2.id());
+        verify(gameRepository, never()).load(syncedGame3.id());
+        verify(gameRepository, times(2)).load(anyInt());
+        verify(gameRepository, times(2)).save(updatedGame);
+    }
+
+    @Test
+    public void given_loadError_When_refreshingData_Then_ShouldKeepRefreshingData() throws Exception {
+        Game syncedGame1 = Game.create(0, "title");
+        syncedGame1.syncedAt = System.currentTimeMillis();
+        Game syncedGame2 = Game.create(1, "title");
+        syncedGame2.syncedAt = System.currentTimeMillis();
+        Game unsyncedGame1 = Game.create(2, "title");
+        Game syncedGame3 = Game.create(3, "title");
+        syncedGame3.syncedAt = System.currentTimeMillis();
+        Game unsyncedGame2 = Game.create(4, "title");
+
+        List<GameRelation> relations = new ArrayList<>();
+        relations.add(GameRelation.create(syncedGame1, System.currentTimeMillis()));
+        relations.add(GameRelation.create(syncedGame2, System.currentTimeMillis()));
+        relations.add(GameRelation.create(unsyncedGame1, System.currentTimeMillis()));
+        relations.add(GameRelation.create(unsyncedGame2, System.currentTimeMillis()));
+        relations.add(GameRelation.create(syncedGame3, System.currentTimeMillis()));
+        doReturn(Observable.just(relations)).when(relationRepository).loadAll();
+
+        final Game updatedGame = Game.create(100, "updated_title");
+        doReturn(Observable.just(updatedGame)).when(gameRepository).load(4);
+        doReturn(Observable.error(new Exception("foo"))).when(gameRepository).load(2);
+        doAnswer(invocation -> Completable.complete()).when(gameRepository).save(any());
+
+        // Act
+        TestObserver<Game> result = manager.sync().test();
+        result.awaitTerminalEvent();
+
+        // Assert
+        verify(relationRepository).loadAll();
+        verify(gameRepository).load(unsyncedGame1.id());
+        verify(gameRepository).load(unsyncedGame2.id());
+        verify(gameRepository, never()).load(syncedGame1.id());
+        verify(gameRepository, never()).load(syncedGame2.id());
+        verify(gameRepository, never()).load(syncedGame3.id());
+        verify(gameRepository, times(2)).load(anyInt());
+        verify(gameRepository).save(unsyncedGame1);
+        verify(gameRepository).save(updatedGame);
+    }
+}


### PR DESCRIPTION
Adds a manager that allows to sync game data associated with user
relations. For this, a new service called GameRelationSyncService
has been added, and iGameDatasources adds a syncedAt value that every
source of data should implement.